### PR TITLE
✨ Use uv tool for cellxgene-schema

### DIFF
--- a/docs/cellxgene-curate.ipynb
+++ b/docs/cellxgene-curate.ipynb
@@ -29,7 +29,9 @@
    },
    "outputs": [],
    "source": [
-    "# !pip install 'lamindb[bionty,jupyter]' cellxgene-lamin cellxgene-schema==5.1.1\n",
+    "# !pip install 'lamindb[bionty,jupyter]' cellxgene-lamin\n",
+    "# cellxgene-schema has pinned dependencies. Therefore we recommend installing it into a separate environment using `uv` or `pipx`\n",
+    "# uv tool install cellxgene-schema==5.1.1\n",
     "!lamin init --storage ./test-cellxgene-curate --schema bionty"
    ]
   },
@@ -88,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "!cellxgene-schema validate anndata_human_immune_cells.h5ad"
+    "!MPLBACKEND=agg uvx cellxgene-schema validate anndata_human_immune_cells.h5ad"
    ]
   },
   {
@@ -498,7 +500,7 @@
    },
    "outputs": [],
    "source": [
-    "!cellxgene-schema validate anndata_human_immune_cells_cxg.h5ad"
+    "!MPLBACKEND=agg uvx cellxgene-schema validate anndata_human_immune_cells_cxg.h5ad"
    ]
   },
   {

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,10 +38,9 @@ def install(session: nox.Session, group: str) -> None:
     elif group == "validator":
         extras = "bionty,jupyter,aws,zarr"
         run(session, "uv pip install --system tiledbsoma")
-        run(session, "uv pip install --system cellxgene-schema==5.1.1")
+        run(session, "uv tool install --system cellxgene-schema==5.1.1")
     install_lamindb(session, branch="main", extras=extras)
     run(session, "uv pip install --system .[dev]")
-    run(session, "uv pip install --system numpy==1.23.2")  # issue 94
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,7 @@ def install(session: nox.Session, group: str) -> None:
     elif group == "validator":
         extras = "bionty,jupyter,aws,zarr"
         run(session, "uv pip install --system tiledbsoma")
-        run(session, "uv tool install --system cellxgene-schema==5.1.1")
+        run(session, "uv tool install cellxgene-schema==5.1.1")
     install_lamindb(session, branch="main", extras=extras)
     run(session, "uv pip install --system .[dev]")
 


### PR DESCRIPTION
Fixes #98 

- Now use `uv tools` to install `cellxgene-schema`
- Currently requires the plotting backend to be specified. I'm looking to improve this in a follow up PR as soon as I know of a better way to inject it into the `uv tool` environment