### PR TITLE
🎨 Fix cellxgene-schema CLI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,14 +31,13 @@ def lint(session: nox.Session) -> None:
 )
 def install(session: nox.Session, group: str) -> None:
     extras = ""
-    run(session, "uv pip install --system scipy>=1.12.0,<1.13.0rc1")
     if group == "census":
         extras = "bionty,jupyter,aws"
         run(session, "uv pip install --system tiledbsoma")
     elif group == "validator":
         extras = "bionty,jupyter,aws,zarr"
         run(session, "uv pip install --system tiledbsoma")
-        run(session, "uv tool install cellxgene-schema==5.1.1")
+        run(session, "uv tool install cellxgene-schema==5.2.2")
     install_lamindb(session, branch="main", extras=extras)
     run(session, "uv pip install --system .[dev]")
 


### PR DESCRIPTION
- Removes the scipy pin that we no longer need
- Pins cellxgene-schema to a version that does not break 